### PR TITLE
Remove additional `using`s from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This package estimates generalized linear models with high dimensional categoric
 ## Example use
 
 ```julia
-using GLFixedEffectModels, GLM, Distributions
+using GLFixedEffectModels
 using RDatasets
 
 df = dataset("datasets", "iris")


### PR DESCRIPTION
Now that `GLM` is re-exported, `using GLM, Distributions` is not necessary anymore to run the example in the README, so I think this can go.