### PR TITLE
Add bias correction feature

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,25 +1,25 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[ArgTools]]
-uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-
 [[Artifacts]]
+deps = ["Pkg"]
+git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.3.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CategoricalArrays]]
-deps = ["DataAPI", "Future", "JSON", "Missings", "Printf", "RecipesBase", "Statistics", "StructTypes", "Unicode"]
-git-tree-sha1 = "1562002780515d2573a4fb0c3715e4e57481075e"
+deps = ["DataAPI", "Future", "JSON", "Missings", "Printf", "Statistics", "StructTypes", "Unicode"]
+git-tree-sha1 = "18d7f3e82c1a80dd38c16453b8fd3f0a7db92f23"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.10.0"
+version = "0.9.7"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "b391f22252b8754f4440de1f37ece49d8a7314bb"
+git-tree-sha1 = "dcc25ff085cf548bc8befad5ce048391a7c07d40"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.44"
+version = "0.10.11"
 
 [[Combinatorics]]
 git-tree-sha1 = "08c8b6831dc00bfea825826be0bc8336fc369860"
@@ -28,13 +28,21 @@ version = "1.0.2"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "e4e2b39db08f967cc1360951f01e8a75ec441cab"
+git-tree-sha1 = "dc7dedc2c2aa9faf59a55c622760a25cbefbe941"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.30.0"
+version = "3.31.0"
 
 [[CompilerSupportLibraries_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "8e695f735fca77e9708e795eda62afdb869cbb70"
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "0.3.4+0"
+
+[[Conda]]
+deps = ["JSON", "VersionParsing"]
+git-tree-sha1 = "299304989a5e6473d985212c28928899c74e9421"
+uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+version = "1.5.2"
 
 [[Crayons]]
 git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
@@ -42,15 +50,15 @@ uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 version = "4.0.4"
 
 [[DataAPI]]
-git-tree-sha1 = "dfb3b7e89e395be1e25c2ad6d7690dc29cc53b1d"
+git-tree-sha1 = "ee400abb2298bd13bfc3df1c412ed228061a2385"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.6.0"
+version = "1.7.0"
 
 [[DataFrames]]
 deps = ["Compat", "DataAPI", "Future", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrettyTables", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "66ee4fe515a9294a8836ef18eea7239c6ac3db5e"
+git-tree-sha1 = "1dadfca11c0e08e03ab15b63aaeda55266754bad"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.1.1"
+version = "1.2.0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -82,26 +90,22 @@ uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 version = "0.24.18"
 
 [[DocStringExtensions]]
-deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "9d4f64f79012636741cf01133158a54b24924c32"
+deps = ["LibGit2"]
+git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.4"
-
-[[Downloads]]
-deps = ["ArgTools", "LibCURL", "NetworkOptions"]
-uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "0.8.5"
 
 [[FillArrays]]
 deps = ["LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "31939159aeb8ffad1d4d8ee44d07f8558273120a"
+git-tree-sha1 = "693210145367e7685d8604aee33d9bfb85db8b31"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.11.7"
+version = "0.11.9"
 
 [[FixedEffects]]
 deps = ["DataAPI", "LinearAlgebra", "Printf", "Requires", "StatsBase"]
-git-tree-sha1 = "f24fdc3220b131cdbf26107605bacc48f7ece2e4"
+git-tree-sha1 = "efe6e0058e80892199bf581d1be8a52eede79e38"
 uuid = "c8885935-8500-56a7-9867-7708b20db0eb"
-version = "2.0.4"
+version = "2.0.3"
 
 [[Formatting]]
 deps = ["Printf"]
@@ -114,10 +118,10 @@ deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[GLM]]
-deps = ["Distributions", "LinearAlgebra", "Printf", "Random", "Reexport", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "StatsModels"]
-git-tree-sha1 = "dc577ad8b146183c064b30e747e3afc6d6dfd62b"
+deps = ["Distributions", "LinearAlgebra", "Printf", "Reexport", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "StatsModels"]
+git-tree-sha1 = "f564ce4af5e79bb88ff1f4488e64363487674278"
 uuid = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
-version = "1.4.2"
+version = "1.5.1"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -146,21 +150,9 @@ git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.1"
 
-[[LibCURL]]
-deps = ["LibCURL_jll", "MozillaCACerts_jll"]
-uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-
-[[LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
-uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-
 [[LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
-
-[[LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
-uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -171,9 +163,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LogExpFunctions]]
 deps = ["DocStringExtensions", "LinearAlgebra"]
-git-tree-sha1 = "1ba664552f1ef15325e68dc4c05c3ef8c2d5d885"
+git-tree-sha1 = "7bd5f6565d80b6bf753738d2bc40a5dfea072070"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.2.4"
+version = "0.2.5"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -181,10 +173,6 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-
-[[MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 
 [[Missings]]
 deps = ["DataAPI"]
@@ -195,17 +183,11 @@ version = "1.0.0"
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
-[[MozillaCACerts_jll]]
-uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-
-[[NetworkOptions]]
-uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-
 [[OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "b9b8b8ed236998f91143938a760c2112dceeb2b4"
+git-tree-sha1 = "9db77584158d0ab52307f8c04f8e7c08ca76b5b3"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
-version = "0.5.4+0"
+version = "0.5.3+4"
 
 [[OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
@@ -214,9 +196,9 @@ version = "1.4.1"
 
 [[PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "f82a0e71f222199de8e9eb9a09977bd0767d52a0"
+git-tree-sha1 = "4dd403333bcf0909341cfe57ec115152f937d7d8"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.0"
+version = "0.11.1"
 
 [[Parameters]]
 deps = ["OrderedCollections", "UnPack"]
@@ -231,7 +213,7 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "1.1.0"
 
 [[Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PooledArrays]]
@@ -248,9 +230,9 @@ version = "1.2.2"
 
 [[PrettyTables]]
 deps = ["Crayons", "Formatting", "Markdown", "Reexport", "Tables"]
-git-tree-sha1 = "b60494adf99652d220cdef46f8a32232182cc22d"
+git-tree-sha1 = "0d1245a357cc61c8cd61934c07447aa569ff22e6"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-version = "1.0.1"
+version = "1.1.0"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -262,23 +244,24 @@ git-tree-sha1 = "12fbe86da16df6679be7521dfb39fbc861e1dc7b"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 version = "2.4.1"
 
+[[RCall]]
+deps = ["CategoricalArrays", "Conda", "DataFrames", "DataStructures", "Dates", "Libdl", "Missings", "REPL", "Random", "Requires", "StatsModels", "WinReg"]
+git-tree-sha1 = "80a056277142a340e646beea0e213f9aecb99caa"
+uuid = "6f49c342-dc21-5d91-9882-a32aef131414"
+version = "0.13.12"
+
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
-[[RecipesBase]]
-git-tree-sha1 = "b3fb709f3c97bfc6e948be68beeecb55a0b340ae"
-uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "1.1.1"
-
 [[Reexport]]
-git-tree-sha1 = "57d8440b0c7d98fc4f889e478e80f268d534c9d5"
+git-tree-sha1 = "5f6c21241f0f655da3952fd60aa18477cf96c220"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
-version = "1.0.0"
+version = "1.1.0"
 
 [[Requires]]
 deps = ["UUIDs"]
@@ -288,15 +271,15 @@ version = "1.1.3"
 
 [[Rmath]]
 deps = ["Random", "Rmath_jll"]
-git-tree-sha1 = "bf3188feca147ce108c76ad82c2792c57abe7b1f"
+git-tree-sha1 = "86c5647b565873641538d8f812c04e4c9dbeb370"
 uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
-version = "0.7.0"
+version = "0.6.1"
 
 [[Rmath_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "68db32dff12bb6127bac73c209881191bf0efbb7"
+git-tree-sha1 = "1b7bf41258f6c5c9c31df8c1ba34c1fc88674957"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
-version = "0.3.0+0"
+version = "0.2.2+2"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -318,9 +301,9 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[SortingAlgorithms]]
 deps = ["DataStructures"]
-git-tree-sha1 = "2ec1962eba973f383239da22e75218565c390a96"
+git-tree-sha1 = "b3363d7460f7d098ca0912c69b082f75625d7508"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "1.0.0"
+version = "1.0.1"
 
 [[SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
@@ -328,9 +311,9 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
 deps = ["ChainRulesCore", "LogExpFunctions", "OpenSpecFun_jll"]
-git-tree-sha1 = "c467f25b6ec4167ea3a9a4351c66c2e1cba5da33"
+git-tree-sha1 = "a50550fa3164a8c46747e62063b4d774ac1bcf49"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.4.1"
+version = "1.5.1"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -355,9 +338,9 @@ version = "0.9.8"
 
 [[StatsModels]]
 deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Printf", "ShiftedArrays", "SparseArrays", "StatsBase", "StatsFuns", "Tables"]
-git-tree-sha1 = "0bac85a98ffc5b81503b49004517ee83f12f0ef6"
+git-tree-sha1 = "dfdf16cc1e531e154c7e62cd42d531e00f8d100e"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.22"
+version = "0.6.23"
 
 [[StructTypes]]
 deps = ["Dates", "UUIDs"]
@@ -371,7 +354,9 @@ uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[TOML]]
 deps = ["Dates"]
+git-tree-sha1 = "44aaac2d2aec4a850302f9aa69127c74f0c3787e"
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
 
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
@@ -381,16 +366,12 @@ version = "1.0.1"
 
 [[Tables]]
 deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
-git-tree-sha1 = "c9d2d262e9a327be1f35844df25fe4561d258dc9"
+git-tree-sha1 = "8ed4a3ea724dac32670b062be3ef1c1de6773ae8"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.4.2"
-
-[[Tar]]
-deps = ["ArgTools", "SHA"]
-uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.4.4"
 
 [[Test]]
-deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[UUIDs]]
@@ -405,14 +386,13 @@ version = "1.0.2"
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
-[[Zlib_jll]]
-deps = ["Libdl"]
-uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+[[VersionParsing]]
+git-tree-sha1 = "80229be1f670524750d905f8fc8148e5a8c4537f"
+uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
+version = "1.2.0"
 
-[[nghttp2_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-
-[[p7zip_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+[[WinReg]]
+deps = ["Test"]
+git-tree-sha1 = "808380e0a0483e134081cc54150be4177959b5f4"
+uuid = "1b915085-20d7-51cf-bf83-8f477d6f5128"
+version = "0.3.1"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -38,12 +38,6 @@ git-tree-sha1 = "8e695f735fca77e9708e795eda62afdb869cbb70"
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "0.3.4+0"
 
-[[Conda]]
-deps = ["JSON", "VersionParsing"]
-git-tree-sha1 = "299304989a5e6473d985212c28928899c74e9421"
-uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.5.2"
-
 [[Crayons]]
 git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
 uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
@@ -244,12 +238,6 @@ git-tree-sha1 = "12fbe86da16df6679be7521dfb39fbc861e1dc7b"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 version = "2.4.1"
 
-[[RCall]]
-deps = ["CategoricalArrays", "Conda", "DataFrames", "DataStructures", "Dates", "Libdl", "Missings", "REPL", "Random", "Requires", "StatsModels", "WinReg"]
-git-tree-sha1 = "80a056277142a340e646beea0e213f9aecb99caa"
-uuid = "6f49c342-dc21-5d91-9882-a32aef131414"
-version = "0.13.12"
-
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
@@ -385,14 +373,3 @@ version = "1.0.2"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-
-[[VersionParsing]]
-git-tree-sha1 = "80229be1f670524750d905f8fc8148e5a8c4537f"
-uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
-version = "1.2.0"
-
-[[WinReg]]
-deps = ["Test"]
-git-tree-sha1 = "808380e0a0483e134081cc54150be4177959b5f4"
-uuid = "1b915085-20d7-51cf-bf83-8f477d6f5128"
-version = "0.3.1"

--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,6 @@ julia = "1"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -48,4 +47,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Statistics", "RDatasets", "StableRNGs", "RCall"]
+test = ["Test", "Random", "Statistics", "RDatasets", "StableRNGs"]

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,6 @@ GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -41,12 +40,12 @@ julia = "1"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 
 [targets]
-test = ["Test", "Random", "Statistics", "RDatasets", "StableRNGs","RCall"]
+test = ["Test", "Random", "Statistics", "RDatasets", "StableRNGs", "RCall"]

--- a/Project.toml
+++ b/Project.toml
@@ -46,6 +46,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 
 [targets]
 test = ["Test", "Random", "Statistics", "RDatasets", "StableRNGs","RCall"]

--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -23,9 +24,9 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+CategoricalArrays = "0.9"
 Combinatorics = "1"
 Compat = "2, 3"
-CategoricalArrays = "0.9"
 DataFrames = "1"
 Distributions = "0.24"
 FillArrays = "0.11"
@@ -47,4 +48,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Statistics", "RDatasets", "StableRNGs", "RCall"]
+test = ["Test", "Random", "Statistics", "RDatasets", "StableRNGs","RCall"]

--- a/Project.toml
+++ b/Project.toml
@@ -47,4 +47,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Statistics", "RDatasets", "StableRNGs"]
+test = ["Test", "Random", "Statistics", "RDatasets", "StableRNGs", "RCall"]

--- a/src/GLFixedEffectModels.jl
+++ b/src/GLFixedEffectModels.jl
@@ -48,6 +48,7 @@ include("utils/tss.jl")
 include("utils/fixedeffects.jl")
 include("utils/basecol.jl")
 include("utils/formula.jl")
+include("utils/biascorr.jl")
 
 include("vcov/Vcov.jl")
 

--- a/src/GLFixedEffectModels.jl
+++ b/src/GLFixedEffectModels.jl
@@ -35,7 +35,8 @@ GLFixedEffectModel,
 has_fe,
 Vcov,
 VcovData,
-responsename
+responsename,
+BiasCorr
 
 ##############################################################################
 ##

--- a/src/utils/biascorr.jl
+++ b/src/utils/biascorr.jl
@@ -2,6 +2,7 @@ function BiasCorr(model::GLFixedEffectModel,L::Int64,panel_structure::Any,df::Da
     # TO-DO: add choice of L (binwidth), see Hahn and Kuersteiner (2011)
     @assert ncol(model.augmentdf) > 1 "please save the entire augmented data frame in order to do bias correction"
     @assert panel_structure in ["classic", "network"] "you can only choose 'classic' or 'network' for panel_structure"
+    # TO-DO: different panel_structure only makes a difference when binwidth is not 0
     @assert typeof(model.distribution) <: Binomial "currently only support binomial distribution"
     @assert typeof(model.link) <: Union{GLM.LogitLink,GLM.ProbitLink} "currently only support probit and logit link"
     @assert ncol(model.augmentdf) in [3,4] "We only support two-way and three-way FE at the moment"
@@ -86,7 +87,7 @@ function groupSums(M::Array{Float64,2},w::Array{Float64,1},group_seg::Array{Arra
     return b_temp
 end
 
-function getGroupSeg(fe::Array{Any,1})
+function getGroupSeg(fe::Array{T,1} where T <: Any)
     theLevels = levels(fe)
 
     list_of_index = Array{Array{Bool,1},1}(undef,0)

--- a/src/utils/biascorr.jl
+++ b/src/utils/biascorr.jl
@@ -1,0 +1,99 @@
+function BiasCorr(model::GLFixedEffectModel,L::Int64,panel_structure::Any,df::DataFrame)
+    # TO-DO: add choice of L (binwidth), see Hahn and Kuersteiner (2011)
+    @assert ncol(model.augmentdf) > 1 "please save the entire augmented data frame in order to do bias correction"
+    @assert panel_structure in ["classic", "network"] "you can only choose 'classic' or 'network' for panel_structure"
+    @assert typeof(model.distribution) <: Binomial "currently only support binomial distribution"
+    @assert typeof(model.link) <: Union{GLM.LogitLink,GLM.ProbitLink} "currently only support probit and logit link"
+    @assert ncol(model.augmentdf) in [3,4] "We only support two-way and three-way FE at the moment"
+    link = model.link
+    y = df[model.esample,model.yname]
+    residuals = model.augmentdf.residuals
+    η = y - residuals
+    μ = GLM.linkinv.(Ref(link),η)
+    μη = GLM.mueta.(Ref(link),η)
+    score = model.gradient
+    hessian = model.hessian
+
+    ## Use the values in saved FE to distinguish groups (Is this reliable?)
+    fes = select(model.augmentdf, Not(:residuals))
+
+
+    if typeof(model.link) <: GLM.LogitLink
+        v = y .- μ
+        w = μη
+        z = w .* (1.0 .- 2.0 .* μ)
+    else
+        w = μη ./ (μ.*(1.0 .- μ))
+        v = w .* (y - μ)
+        w = w .* μη
+        z = - η .* w
+    end
+    
+    MX_times_z = score ./ v .* z
+    P = size(MX_times_z)[2]
+    b = zeros(P)
+
+    if panel_structure == "classic"
+        @assert size(fes)[2] != 3 "panel.structure == 'classic' expects a two-way fixed effects model."
+        for fe in eachcol(fes)
+            b += groupSums(MX_times_z, w, getGroupSeg(fe)) ./ 2.0
+        end
+    else
+        for fe in eachcol(fes)
+            b += groupSums(MX_times_z, w, getGroupSeg(fe)) ./ 2.0
+        end
+    end
+
+    β = model.coef + hessian \ b
+    return GLFixedEffectModel(
+        β,
+        model.vcov,
+        model.vcov_type,
+        model.nclusters,
+        model.iterations,
+        model.converged,
+        model.esample,
+        model.augmentdf,
+        model.distribution,
+        model.link,
+        model.coefnames,
+        model.yname,
+        model.formula,
+        model.formula_schema,
+        model.nobs,
+        model.dof_residual,
+        model.deviance,
+        model.nulldeviance,
+        model.gradient,
+        model.hessian
+    )
+
+end
+
+function groupSums(M::Array{Float64,2},w::Array{Float64,1},group_seg::Array{Array{Bool,1},1})
+    P = size(M)[2] # number of regressos P
+    b_temp = zeros(P)
+
+    for seg_index in group_seg
+        numerator = zeros(P)
+        for p in 1:P
+            numerator[p] += sum(M[seg_index,p])
+        end
+
+        denominator = sum(w[seg_index])
+        b_temp += numerator./denominator
+    end
+    return b_temp
+end
+
+function getGroupSeg(fe::Array{Any,1})
+    theLevels = levels(fe)
+
+    list_of_index = Array{Array{Bool,1},1}(undef,0)
+    
+    for level in theLevels
+        push!(list_of_index,fe .== level)
+    end
+
+    return list_of_index 
+end

--- a/src/utils/biascorr.jl
+++ b/src/utils/biascorr.jl
@@ -24,7 +24,7 @@ function BiasCorr(model::GLFixedEffectModel,df::DataFrame;L::Int64=0,panel_struc
     #         but this didn't show up in their documentation. 
     #         This can lead to inaccurate results (one can test alpaca::biasCorr with L>0 and with two different formula y~x|i+t and y~x|t+i).
     #         Is this the best practice? should we also implemented the bandwidth this way? At least we need to include this in the user manual.
-    # TO-DO: check if df is sorted. It must be sorted to produce the right result when panel_structure == "network" and L > 0
+    # TO-DO: check if `df` is sorted. It must be sorted to produce the right result when L > 0
     @assert ncol(model.augmentdf) > 1 "please save the entire augmented data frame in order to do bias correction"
     @assert panel_structure in ["classic", "network"] "you can only choose 'classic' or 'network' for panel_structure"
     @assert typeof(model.distribution) <: Binomial "currently only support binomial distribution"
@@ -66,7 +66,7 @@ function BiasCorr(model::GLFixedEffectModel,df::DataFrame;L::Int64=0,panel_struc
         # assuming the time fe in the fomula always comes the last
         b += groupSumsSpectral(score ./ v .* w, v, w, L,getGroupSeg(fes[!,1]))
     else
-        # assuming the in the two-way network structure, the first two FEs are always it and jt.
+        # assuming that in the two-way network structure, the first two FEs are always it and jt.
         for fe in eachcol(fes)
             b += groupSums(MX_times_z, w, getGroupSeg(fe)) ./ 2.0
         end

--- a/src/utils/biascorr.jl
+++ b/src/utils/biascorr.jl
@@ -18,10 +18,10 @@ Always turn on the save option when running `nlreg()` before invoking `BiasCorr(
 function BiasCorr(model::GLFixedEffectModel,df::DataFrame;L::Int64=0,panel_structure::Any="classic")
     # TO-DO: add choice of L (binwidth)
     # UPDATE: The procedures that use the bandwidth L should be applied to the time dimension. 
-    #         alpaca::biasCorr in R didn't automatically distinguish between individual fe and time fe. 
+    #         alpaca::biasCorr in R doesn't automatically distinguish between individual fe and time fe. 
     #         When constructing Bhat (notation inhereted from Fernández-Val and Weidner, Annual Review of Economics (2018), pp120),
-    #         alpaca distinguish i dimension and t dimension according to the variable positions in the formula,
-    #         but this didn't show up in their documentation. 
+    #         alpaca distinguishes i dimension and t dimension according to the variable positions in the formula,
+    #         but this doesn't show up in their documentation. 
     #         This can lead to inaccurate results (one can test alpaca::biasCorr with L>0 and with two different formula y~x|i+t and y~x|t+i).
     #         Is this the best practice? should we also implemented the bandwidth this way? At least we need to include this in the user manual.
     # TO-DO: check if `df` is sorted. It must be sorted to produce the right result when L > 0
@@ -66,7 +66,7 @@ function BiasCorr(model::GLFixedEffectModel,df::DataFrame;L::Int64=0,panel_struc
         # assuming the time fe in the fomula always comes the last
         b += groupSumsSpectral(score ./ v .* w, v, w, L,getGroupSeg(fes[!,1]))
     else
-        # assuming that in the two-way network structure, the first two FEs are always it and jt.
+        # assuming that with network structure, the first two FEs are always it and jt.
         for fe in eachcol(fes)
             b += groupSums(MX_times_z, w, getGroupSeg(fe)) ./ 2.0
         end

--- a/src/utils/biascorr.jl
+++ b/src/utils/biascorr.jl
@@ -1,8 +1,24 @@
-function BiasCorr(model::GLFixedEffectModel,L::Int64,panel_structure::Any,df::DataFrame)
-    # TO-DO: add choice of L (binwidth), see Hahn and Kuersteiner (2011)
+"""
+    BiasCorr(model::GLFixedEffectModel,df::DataFrame;L::Int64=0,panel_structure::Any="classic")
+
+Asymptotic bias correction after fitting binary choice models with a two-/three-way error.
+
+# Arguments
+## Required Arguments
+- `model::Integer`: a `GLFixedEffectModel` object which can be obtained by using `nlreg()`.
+- `df::DataFrame`: the Data Frame on which you just run `nlreg()`.
+## Optional Arguments
+- `L:Int64`: choice of binwidth, see Hahn and Kuersteiner (2011). The default value is 0.
+- `panel_structure`: choose from "classic" or "network". The default value is "classic".
+
+# Notice
+This function only supports binomial distribution and probit/logit link. It also only supports two-way and three-way FE at the moment.
+Always turn on the save option when running `nlreg()` before invoking `BiasCorr()`.
+"""
+function BiasCorr(model::GLFixedEffectModel,df::DataFrame;L::Int64=0,panel_structure::Any="classic")
+    # TO-DO: add choice of L (binwidth)
     @assert ncol(model.augmentdf) > 1 "please save the entire augmented data frame in order to do bias correction"
     @assert panel_structure in ["classic", "network"] "you can only choose 'classic' or 'network' for panel_structure"
-    # TO-DO: different panel_structure only makes a difference when binwidth is not 0
     @assert typeof(model.distribution) <: Binomial "currently only support binomial distribution"
     @assert typeof(model.link) <: Union{GLM.LogitLink,GLM.ProbitLink} "currently only support probit and logit link"
     @assert ncol(model.augmentdf) in [3,4] "We only support two-way and three-way FE at the moment"

--- a/test/biascorr_test.jl
+++ b/test/biascorr_test.jl
@@ -4,7 +4,7 @@ using Distributions, CategoricalArrays
 using RDatasets, Test, Random
 using StableRNGs
 
-using GLM: LogitLink
+using GLM: LogitLink, ProbitLink
 
 rng = StableRNG(1234)
 
@@ -17,7 +17,44 @@ a = ["A","B","C"]
 df.Random = vec([a[i] for i in idx])
 df.RandomCategorical = df.Random
 
-# Two-way Logit
+# Set up R
+using RCall
+R"library(alpaca)"
+df_r = deepcopy(df)
+@rput df_r
+
+# Test 1: Two-way Logit
+R"""
+res1 <- alpaca::feglm(binary ~ SepalWidth | SpeciesDummy + RandomCategorical , df_r, binomial(), beta.start = c(0.2))
+res_bc1 <- alpaca::biasCorr(res1)
+coef1 <- res_bc1[["coefficients"]]
+"""
+@rget coef1
+
 m = GLFixedEffectModels.@formula binary ~ SepalWidth + GLFixedEffectModels.fe(SpeciesDummy) + GLFixedEffectModels.fe(RandomCategorical)
 x = GLFixedEffectModels.nlreg(df, m, Binomial(), LogitLink(), start = [0.2], save=true)
 x_afterbc = GLFixedEffectModels.BiasCorr(x, df)
+
+@test x_afterbc.coef ≈ [coef1] atol = 1e-4
+
+# Test 2: Two-way Probit
+#= R"""
+res2 <- alpaca::feglm(binary ~ SepalWidth | SpeciesDummy + RandomCategorical , df_r, binomial(link = "probit"), beta.start = c(0.2))
+res_bc2 <- alpaca::biasCorr(res2)
+coef2 <- res_bc2[["coefficients"]]
+"""
+@rget coef2
+
+x = GLFixedEffectModels.nlreg(df, m, Binomial(), ProbitLink(), start = [0.2], save=true)
+x_afterbc = GLFixedEffectModels.BiasCorr(x, df)
+@test coef(x_afterbc) ≈ [coef2] atol = 1e-4 =#
+
+# Test 2 fails to pass. It seems like the result before bias correction is already different
+R"""
+res2 <- alpaca::feglm(binary ~ SepalWidth | SpeciesDummy + RandomCategorical , df_r, binomial(link = "probit"), beta.start = c(0.2))
+coef2_wobc <- res2[["coefficients"]]
+"""
+@rget coef2_wobc
+
+x = GLFixedEffectModels.nlreg(df, m, Binomial(), ProbitLink(), start = [0.2], save=true)
+@test x.coef ≈ [coef2_wobc] atol = 1e-4

--- a/test/biascorr_test.jl
+++ b/test/biascorr_test.jl
@@ -5,6 +5,7 @@ using RDatasets, Test, Random
 using StableRNGs
 
 using GLM: LogitLink, ProbitLink
+# using RCall
 
 rng = StableRNG(1234)
 
@@ -17,35 +18,32 @@ a = ["A","B","C"]
 df.Random = vec([a[i] for i in idx])
 df.RandomCategorical = df.Random
 
-# Set up R
-using RCall
-R"""
-install.packages("alpaca")
-"""
-R"library(alpaca)"
-df_r = deepcopy(df)
-@rput df_r
-
 # Test 1: Two-way Logit
 # See if the coefficients after bias correction match with the results obtained from R package alpaca
-R"""
+
+#= R"""
 res1 <- alpaca::feglm(binary ~ SepalWidth | SpeciesDummy + RandomCategorical , df_r, binomial(), beta.start = c(0.2))
 res_bc1 <- alpaca::biasCorr(res1)
 coef1 <- res_bc1[["coefficients"]]
 """
 @rget coef1
+###############################
+coef1 = 7.214197357443702
+###############################
+=#
 
 m = GLFixedEffectModels.@formula binary ~ SepalWidth + GLFixedEffectModels.fe(SpeciesDummy) + GLFixedEffectModels.fe(RandomCategorical)
 x = GLFixedEffectModels.nlreg(df, m, Binomial(), LogitLink(), start = [0.2], save=true)
 x_afterbc = GLFixedEffectModels.BiasCorr(x, df)
 
-@test x_afterbc.coef ≈ [coef1] atol = 1e-4
+@test x_afterbc.coef ≈ [7.214197357443702] atol = 1e-4
 
 # Test 2: Two-way Probit
 # Since the coefficients for models that use the probit link didn't match the results from R's alpaca before bias correction
 # We test if the ``net adjusted value`` for the coefficients matches, for now.
 # TODO: check why probit link didn't work as expected
-R"""
+
+#=R"""
 res2 <- alpaca::feglm(binary ~ SepalWidth | SpeciesDummy + RandomCategorical , df_r, binomial(link = "probit"), beta.start = c(0.2))
 res_bc2 <- alpaca::biasCorr(res2)
 coef2<- res2[["coefficients"]]
@@ -53,32 +51,43 @@ coef2_afterbc <- res_bc2[["coefficients"]]
 net_adjusted_value = coef2_afterbc - coef2
 """
 @rget net_adjusted_value
+###############################
+net_adjusted_value = -0.5381054072387927
+###############################
+=#
 
 x = GLFixedEffectModels.nlreg(df, m, Binomial(), ProbitLink(), start = [0.2], save=true)
 x_afterbc = GLFixedEffectModels.BiasCorr(x, df)
-@test x_afterbc.coef - x.coef ≈ [net_adjusted_value] atol = 1e-4
+@test x_afterbc.coef - x.coef ≈ [-0.5381054072387927] atol = 1e-4
 
 # Test 3: Three-way Logit (I = 5, J = 6, T = 7), Network structure
+I, J, T = 5, 6, 7
+i_index = repeat(1:I,inner = J*T)
+j_index = repeat(1:J,outer = I, inner = T)
+t_index = repeat(1:T,outer = I*J)
+
+# Reset rng
+rng = StableRNG(1234)
+data = DataFrame(i = i_index, j = j_index, t = t_index, x = rand(rng, I*J*T), y = rand(rng,Bernoulli(), I*J*T))
+
+#= @rput data
 R"""
-data <- alpaca::simGLM(n = 30, t = 7, seed = 1234, model = "logit")
-colnames(data)[1] <- "ij"
-ij <- merge(seq(5),seq(6))
-data$i <- ij$x
-data$j <- ij$y
-data_sorted <- data[order(data$i, data$j, data$t),]
-res3 <- alpaca::feglm(y ~ x1 | i + j + t , data_sorted, binomial(), beta.start = c(0.2))
-res3.bc_L0 <- biasCorr(res3,panel.structure = 'network',L = 0)
-res3.bc_L3 <- biasCorr(res3,panel.structure = 'network',L = 3)
-coef3 <- res3[["coefficients"]]
+res3 <- alpaca::feglm(y ~ x | i + j + t , data, binomial(), beta.start = c(0.2))
+res3.bc_L0 <- alpaca::biasCorr(res3,panel.structure = 'network',L = 0)
+res3.bc_L3 <- alpaca::biasCorr(res3,panel.structure = 'network',L = 3)
 coef_L0 <- res3.bc_L0[["coefficients"]]
 coef_L3 <- res3.bc_L3[["coefficients"]]
 """
-@rget data_sorted coef3 coef_L0 coef_L3
+@rget coef_L0 coef_L3 
+###############################
+coef_L0 = -0.8958868087842135
+coef_L3 = -0.8845864617809618
+###############################
+=#
 
-m = GLFixedEffectModels.@formula y ~ x1 + GLFixedEffectModels.fe(i) + GLFixedEffectModels.fe(j) + GLFixedEffectModels.fe(t)
-x = GLFixedEffectModels.nlreg(data_sorted, m, Binomial(), LogitLink(), start = [0.2], save=true)
-x_bc_L0 = GLFixedEffectModels.BiasCorr(x, data_sorted; panel_structure = "network", L = 0)
-x_bc_L3 = GLFixedEffectModels.BiasCorr(x, data_sorted; panel_structure = "network", L = 3)
-
-@test x_bc_L0.coef ≈ [coef_L0] atol = 1e-4
-@test x_bc_L3.coef ≈ [coef_L3] atol = 1e-4
+m = GLFixedEffectModels.@formula y ~ x + GLFixedEffectModels.fe(i) + GLFixedEffectModels.fe(j) + GLFixedEffectModels.fe(t)
+x = GLFixedEffectModels.nlreg(data, m, Binomial(), LogitLink(), start = [0.2], save=true)
+x_bc_L0 = GLFixedEffectModels.BiasCorr(x, data; panel_structure = "network", L = 0)
+x_bc_L3 = GLFixedEffectModels.BiasCorr(x, data; panel_structure = "network", L = 3)
+@test x_bc_L0.coef ≈ [-0.8958868087842135] atol = 1e-4
+@test x_bc_L3.coef ≈ [-0.8845864617809618] atol = 1e-4

--- a/test/biascorr_test.jl
+++ b/test/biascorr_test.jl
@@ -20,4 +20,4 @@ df.RandomCategorical = df.Random
 # Two-way Logit
 m = GLFixedEffectModels.@formula binary ~ SepalWidth + GLFixedEffectModels.fe(SpeciesDummy) + GLFixedEffectModels.fe(RandomCategorical)
 x = GLFixedEffectModels.nlreg(df, m, Binomial(), LogitLink(), start = [0.2], save=true)
-x_afterbc = GLFixedEffectModels.BiasCorr(x, 0, "classic", df)
+x_afterbc = GLFixedEffectModels.BiasCorr(x, df)

--- a/test/biascorr_test.jl
+++ b/test/biascorr_test.jl
@@ -39,7 +39,7 @@ x_afterbc = GLFixedEffectModels.BiasCorr(x, df)
 @test x_afterbc.coef ≈ [coef1] atol = 1e-4
 
 # Test 2: Two-way Probit
-# Since the coefficients for models that uses the probit link didn't match the results from R's alpaca before bias correction
+# Since the coefficients for models that use the probit link didn't match the results from R's alpaca before bias correction
 # We test if the ``net adjusted value`` for the coefficients matches, for now.
 # TODO: check why probit link didn't work as expected
 R"""

--- a/test/biascorr_test.jl
+++ b/test/biascorr_test.jl
@@ -1,5 +1,5 @@
-include("../src/GLFixedEffectModels.jl")
-
+# include("../src/GLFixedEffectModels.jl")
+using GLFixedEffectModels
 using Distributions, CategoricalArrays
 using RDatasets, Test, Random
 using StableRNGs
@@ -24,6 +24,7 @@ df_r = deepcopy(df)
 @rput df_r
 
 # Test 1: Two-way Logit
+# See if the coefficients after bias correction match with the results obtained from R package alpaca
 R"""
 res1 <- alpaca::feglm(binary ~ SepalWidth | SpeciesDummy + RandomCategorical , df_r, binomial(), beta.start = c(0.2))
 res_bc1 <- alpaca::biasCorr(res1)
@@ -38,23 +39,43 @@ x_afterbc = GLFixedEffectModels.BiasCorr(x, df)
 @test x_afterbc.coef ≈ [coef1] atol = 1e-4
 
 # Test 2: Two-way Probit
-#= R"""
+# Since the coefficients for models that uses the probit link didn't match the results from R's alpaca before bias correction
+# We test if the ``net adjusted value`` for the coefficients matches, for now.
+# TODO: check why probit link didn't work as expected
+R"""
 res2 <- alpaca::feglm(binary ~ SepalWidth | SpeciesDummy + RandomCategorical , df_r, binomial(link = "probit"), beta.start = c(0.2))
 res_bc2 <- alpaca::biasCorr(res2)
-coef2 <- res_bc2[["coefficients"]]
+coef2<- res2[["coefficients"]]
+coef2_afterbc <- res_bc2[["coefficients"]]
+net_adjusted_value = coef2_afterbc - coef2
 """
-@rget coef2
+@rget net_adjusted_value
 
 x = GLFixedEffectModels.nlreg(df, m, Binomial(), ProbitLink(), start = [0.2], save=true)
 x_afterbc = GLFixedEffectModels.BiasCorr(x, df)
-@test coef(x_afterbc) ≈ [coef2] atol = 1e-4 =#
+@test x_afterbc.coef - x.coef ≈ [net_adjusted_value] atol = 1e-4
 
-# Test 2 fails to pass. It seems like the result before bias correction is already different
+# Test 3: Three-way Logit (I = 5, J = 6, T = 7), Network structure
 R"""
-res2 <- alpaca::feglm(binary ~ SepalWidth | SpeciesDummy + RandomCategorical , df_r, binomial(link = "probit"), beta.start = c(0.2))
-coef2_wobc <- res2[["coefficients"]]
+data <- alpaca::simGLM(n = 30, t = 7, seed = 1234, model = "logit")
+colnames(data)[1] <- "ij"
+ij <- merge(seq(5),seq(6))
+data$i <- ij$x
+data$j <- ij$y
+data_sorted <- data[order(data$i, data$j, data$t),]
+res3 <- alpaca::feglm(y ~ x1 | i + j + t , data_sorted, binomial(), beta.start = c(0.2))
+res3.bc_L0 <- biasCorr(res3,panel.structure = 'network',L = 0)
+res3.bc_L3 <- biasCorr(res3,panel.structure = 'network',L = 3)
+coef3 <- res3[["coefficients"]]
+coef_L0 <- res3.bc_L0[["coefficients"]]
+coef_L3 <- res3.bc_L3[["coefficients"]]
 """
-@rget coef2_wobc
+@rget data_sorted coef3 coef_L0 coef_L3
 
-x = GLFixedEffectModels.nlreg(df, m, Binomial(), ProbitLink(), start = [0.2], save=true)
-@test x.coef ≈ [coef2_wobc] atol = 1e-4
+m = GLFixedEffectModels.@formula y ~ x1 + GLFixedEffectModels.fe(i) + GLFixedEffectModels.fe(j) + GLFixedEffectModels.fe(t)
+x = GLFixedEffectModels.nlreg(data_sorted, m, Binomial(), LogitLink(), start = [0.2], save=true)
+x_bc_L0 = GLFixedEffectModels.BiasCorr(x, data_sorted; panel_structure = "network", L = 0)
+x_bc_L3 = GLFixedEffectModels.BiasCorr(x, data_sorted; panel_structure = "network", L = 3)
+
+@test x_bc_L0.coef ≈ [coef_L0] atol = 1e-4
+@test x_bc_L3.coef ≈ [coef_L3] atol = 1e-4

--- a/test/biascorr_test.jl
+++ b/test/biascorr_test.jl
@@ -1,0 +1,23 @@
+include("../src/GLFixedEffectModels.jl")
+
+using Distributions, CategoricalArrays
+using RDatasets, Test, Random
+using StableRNGs
+
+using GLM: LogitLink
+
+rng = StableRNG(1234)
+
+df = dataset("datasets", "iris")
+df.binary = zeros(Float64, size(df,1))
+df[df.SepalLength .> 5.0,:binary] .= 1.0
+df.SpeciesDummy = string.(df.Species)
+idx = rand(rng,1:3,size(df,1),1)
+a = ["A","B","C"]
+df.Random = vec([a[i] for i in idx])
+df.RandomCategorical = df.Random
+
+# Two-way Logit
+m = GLFixedEffectModels.@formula binary ~ SepalWidth + GLFixedEffectModels.fe(SpeciesDummy) + GLFixedEffectModels.fe(RandomCategorical)
+x = GLFixedEffectModels.nlreg(df, m, Binomial(), LogitLink(), start = [0.2], save=true)
+x_afterbc = GLFixedEffectModels.BiasCorr(x, 0, "classic", df)

--- a/test/biascorr_test.jl
+++ b/test/biascorr_test.jl
@@ -19,6 +19,9 @@ df.RandomCategorical = df.Random
 
 # Set up R
 using RCall
+R"""
+install.packages("alpaca")
+"""
 R"library(alpaca)"
 df_r = deepcopy(df)
 @rput df_r

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using GLFixedEffectModels
 
 tests = ["nlreg.jl"
-		 ]
+		 "biascorr_test.jl"]
 
 println("Running tests:")
 


### PR DESCRIPTION
This pull request add the bias correction feature to the GLFixedEffectModels package. It returns the same numerical results with `alpaca::BiasCorr()` in R. 

TO-DO:

- [x] allow the binwidth to be different than 0.
- [ ] do more robustness test with missing values etc.