### PR TITLE
Add SE correction, allow poisson regression to be two-way

### DIFF
--- a/src/utils/biascorr.jl
+++ b/src/utils/biascorr.jl
@@ -36,12 +36,9 @@
 #                  |    2    |  it + jt + ij            |          YES           |                      |  Weidner and Zylkin (2020)
 # --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-
-using CSV
-
-############################################################
+###################################################################
 #                   Main Function bias_correction()               #
-############################################################
+###################################################################
 
 """
     bias_correction(model::GLFixedEffectModel,df::DataFrame;i_symb::Union{Symbol,Nothing}=nothing,j_symb::Union{Symbol,Nothing}=nothing,t_symb::Union{Symbol,Nothing}=nothing,L::Int64=0,panel_structure::Symbol=:classic)

--- a/test/biascorr_test.jl
+++ b/test/biascorr_test.jl
@@ -33,7 +33,7 @@ coef1 = 7.214197357443702
 =#
 
 m = GLFixedEffectModels.@formula binary ~ SepalWidth + GLFixedEffectModels.fe(SpeciesDummy) + GLFixedEffectModels.fe(RandomCategorical)
-x = GLFixedEffectModels.nlreg(df, m, Binomial(), LogitLink(), start = [0.2], save = [:fe,:residuals])
+x = GLFixedEffectModels.nlreg(df, m, Binomial(), LogitLink(), start = [0.2], save = [:mu,:eta])
 x_afterbc = GLFixedEffectModels.bias_correction(x, df; i_symb = :SpeciesDummy, j_symb = :RandomCategorical)
 
 @test x_afterbc.coef ≈ [7.214197357443702] atol = 1e-4
@@ -53,7 +53,7 @@ coef2_afterbc = 4.1962783532153605
 ###############################
 =#
 
-x = GLFixedEffectModels.nlreg(df, m, Binomial(), ProbitLink(), start = [0.2], save=[:fe,:residuals])
+x = GLFixedEffectModels.nlreg(df, m, Binomial(), ProbitLink(), start = [0.2], save=[:mu,:eta])
 x_afterbc = GLFixedEffectModels.bias_correction(x, df; i_symb = :SpeciesDummy, j_symb = :RandomCategorical)
 @test x_afterbc.coef ≈ [4.1962783532153605] atol = 1e-4
 
@@ -87,7 +87,7 @@ coef_L3 = -0.6077559017896819
 =#
 
 m = GLFixedEffectModels.@formula y ~ x + GLFixedEffectModels.fe(i)*GLFixedEffectModels.fe(t) + GLFixedEffectModels.fe(j)*GLFixedEffectModels.fe(t) + GLFixedEffectModels.fe(i)*GLFixedEffectModels.fe(j)
-x = GLFixedEffectModels.nlreg(data, m, Binomial(), LogitLink(), start = [0.2], save=[:fe,:residuals])
+x = GLFixedEffectModels.nlreg(data, m, Binomial(), LogitLink(), start = [0.2], save=[:mu,:eta])
 x_bc_L0 = GLFixedEffectModels.bias_correction(x, data; i_symb = :i, j_symb = :j, t_symb = :t, panel_structure = :network, L = 0)
 x_bc_L3 = GLFixedEffectModels.bias_correction(x, data; i_symb = :i, j_symb = :j, t_symb = :t, panel_structure = :network, L = 3)
 @test x_bc_L0.coef ≈ [-0.5478161609879237] atol = 1e-4
@@ -108,7 +108,7 @@ data = DataFrame(i = i_index, j = j_index, t = t_index, x = rand(rng, I*J*T), y 
 # using CSV
 # CSV.write("test4.csv",data)
 m = GLFixedEffectModels.@formula y ~ x + GLFixedEffectModels.fe(i)*GLFixedEffectModels.fe(t) + GLFixedEffectModels.fe(j)*GLFixedEffectModels.fe(t) + GLFixedEffectModels.fe(i)*GLFixedEffectModels.fe(j)
-x = GLFixedEffectModels.nlreg(data, m, Poisson(), LogLink(), start = [0.2], save=[:fe,:residuals])
+x = GLFixedEffectModels.nlreg(data, m, Poisson(), LogLink(), start = [0.2], save=[:mu,:eta])
 x_afterbc = GLFixedEffectModels.bias_correction(x, data; i_symb = :i, j_symb = :j, t_symb = :t, panel_structure = :network)
 @test x_afterbc.coef ≈ [-0.0088560] atol = 1e-4
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using GLFixedEffectModels
 
-tests = ["nlreg.jl"
-		 ]
+tests = ["nlreg.jl",
+		 "biascorr_test.jl"]
 
 println("Running tests:")
 


### PR DESCRIPTION
This PR adds the feature of standard error correction. It also allows the corrected regression to be two-way (It was three-way only in previous implementation). Up until now, our package covers all functionality of the Stata package `ppml_fe_bias` by Tom Zylkin and the R package `Alpaca::BiasCorr` by Amrei Stammann.