### PR TITLE
Update for FixedEffectModels 1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.10' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GLFixedEffectModels"
 uuid = "bafb0ae5-e5f5-5100-81b6-6a55d777c812"
 authors = ["Johannes Boehm <johannes.boehm@gmail.com>"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -33,4 +33,4 @@ StatsAPI = "1"
 StatsBase = "0.33, 0.34"
 StatsModels = "0.6, 0.7"
 Vcov = "0.7, 0.8"
-julia = "^1.9"
+julia = "^1.10"

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -154,7 +154,7 @@ function nlreg(@nospecialize(df),
     if has_fes
         if drop_singletons
             before_n = sum(esample)
-            FixedEffectModels.drop_singletons!(esample, fes, nthreads)
+            FixedEffectModels.drop_singletons!(esample, fes)
             after_n = sum(esample)
             dropped_n = before_n - after_n
             if dropped_n > 0

--- a/test/separation.jl
+++ b/test/separation.jl
@@ -59,35 +59,35 @@ url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/cs
 df = DataFrame(CSV.File(Downloads.download(url)))
 res1 = nlreg(df, @formula(y ~ x1 + fe(i) + fe(j)), Poisson(), LogLink() ; separation = [:ReLU])
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/01.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/01.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 res1 = nlreg(df, @formula(y ~ x1 + x2 + fe(id1) + fe(id2)), Poisson(), LogLink() ; separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/02.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/02.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 res1 = nlreg(df, @formula(y ~ fe(id1) + fe(id2)), Poisson(), LogLink() ; drop_singletons = false, separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/03.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/03.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 res1 = nlreg(df, @formula(y ~ fe(id1) + fe(id2) + fe(id3)), Poisson(), LogLink() ; separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/04.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/04.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 res1 = nlreg(df, @formula(y ~ fe(id1) + fe(id2)), Poisson(), LogLink() ; separation = [:ReLU])
 # don't test on the last ob because it was a singleton instead of a separation
 @test all(df.separated[1:end-1] .== .~res1.esample[1:end-1])
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/05.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/05.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 # add one fixed effect that is basically a intercept, because nlreg won't run without fe
 df.id = ones(size(df,1))
 res1 = nlreg(df, @formula(y ~ x1 + x2 + x3 + x4 + fe(id)), Poisson(), LogLink() ; separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/06.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/06.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 # add one fixed effect that is basically a intercept, because nlreg won't run without fe
 df.id = ones(size(df,1))
@@ -105,71 +105,72 @@ when setting ppmlhdfe sep as sep(ir), the output is:
 (ReLU method dropped 1 separated observation in 2 iterations)
 and the output gives ill results too.
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/07.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/07.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 res1 = nlreg(df, @formula(y ~ x1 + x2 + fe(id1) + fe(id2)), Poisson(), LogLink() ; drop_singletons = false, separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 =# 
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/08.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/08.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 res1 = nlreg(df, @formula(y ~ x1 + x2 + fe(id1) + fe(id2)), Poisson(), LogLink() ; separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/09.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/09.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 # add one fixed effect that is basically a intercept, because nlreg won't run without fe
 df.id = ones(size(df,1))
 res1 = nlreg(df, @formula(y ~ x1 + x2 + x3 + fe(id)), Poisson(), LogLink() ; separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/10.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/10.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 df.id = ones(size(df,1))
 res1 = nlreg(df, @formula(y ~ x1 + x2 + x3 + fe(id)), Poisson(), LogLink() ; separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/11.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/11.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 df.id = ones(size(df,1))
 res1 = nlreg(df, @formula(y ~ x1 + fe(id)), Poisson(), LogLink() ; separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/12.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/12.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 res1 = nlreg(df, @formula(y ~ fe(id1) + fe(id2)), Poisson(), LogLink() ; drop_singletons = false , separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/13.csv"
-df = DataFrame(CSV.File(Downloads.download(url)))
-res1 = nlreg(df, @formula(y ~ fe(id1) + fe(id2)), Poisson(), LogLink() ; drop_singletons = false , separation = [:ReLU])
-@test all(df.separated .== .~res1.esample)
+# original 13 no longer exists
+# url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/13.csv"
+# df = DataFrame(CSV.File(Downloads.download(url)))
+# res1 = nlreg(df, @formula(y ~ fe(id1) + fe(id2)), Poisson(), LogLink() ; drop_singletons = false , separation = [:ReLU])
+# @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/14.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/13.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 df.id = ones(size(df,1))
 res1 = nlreg(df, @formula(y ~ x1 + x2 + fe(id)), Poisson(), LogLink() ; separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/15.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/14.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 df.id = ones(size(df,1))
 res1 = nlreg(df, @formula(y ~ x1 + x2 + x3 + fe(id)), Poisson(), LogLink() ; separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/16.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/15.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 df.id = ones(size(df,1))
 res1 = nlreg(df, @formula(y ~ x1 + x2 + x3 + fe(id)), Poisson(), LogLink() ; separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/17.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/16.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 df.id = ones(size(df,1))
 res1 = nlreg(df, @formula(y ~ x1 + x2 + x3 + fe(id)), Poisson(), LogLink() ; separation = [:ReLU])
 @test all(df.separated .== .~res1.esample)
 
-url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/test/separation_datasets/18.csv"
+url = "https://raw.githubusercontent.com/sergiocorreia/ppmlhdfe/master/guides/separation_datasets/17.csv"
 df = DataFrame(CSV.File(Downloads.download(url)))
 df.id = ones(size(df,1))
 res1 = nlreg(df, @formula(y ~ x1 + x2 + x3 + fe(id)), Poisson(), LogLink() ; separation = [:ReLU])


### PR DESCRIPTION
FixedEffectModels.jl v1.13 removed the `nthreads` argument from `drop_singletons!`, causing this package to error on precompilation. This should fix that.